### PR TITLE
Fix AST example

### DIFF
--- a/02_00_optional_variant_tuple/CMakeLists.txt
+++ b/02_00_optional_variant_tuple/CMakeLists.txt
@@ -2,6 +2,11 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(02_00_optional_variant_tuple optional_variant_tuple.md)
 endif()
 
-add_executable(02_00_ast
-    code/ast.cpp
-)
+# clang supports parenthesized initialization of aggregates only from version 16 onwards:
+# - https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0960r3.html
+# - https://en.cppreference.com/w/cpp/compiler_support
+if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 15.0))
+    add_executable(02_00_ast
+        code/ast.cpp
+    )
+endif()

--- a/02_00_optional_variant_tuple/code/ast.cpp
+++ b/02_00_optional_variant_tuple/code/ast.cpp
@@ -17,14 +17,14 @@ struct add;
 struct mul;
 
 template <typename... Ts>
-using sp = std::unique_ptr<Ts...>;
+using up = std::unique_ptr<Ts...>;
 
 template <typename T, typename U1, typename U2>
 auto mkop(U1&& u1, U2&& u2) {
     return std::make_unique<T>(std::forward<U1>(u1), std::forward<U2>(u2));
 }
 
-using ast = std::variant<lit, sp<add>, sp<mul>>;
+using ast = std::variant<lit, up<add>, up<mul>>;
 
 struct add {
     ast x, y;
@@ -37,8 +37,8 @@ int eval(ast const& a) {
     return std::visit(
         overloaded(
             [](lit const& l) { return l.x; },
-            [](sp<add> const& a) mutable { return eval(a->x) + eval(a->y); },
-            [](sp<mul> const& m) mutable { return eval(m->x) * eval(m->y); }),
+            [](up<add> const& a) { return eval(a->x) + eval(a->y); },
+            [](up<mul> const& m) { return eval(m->x) * eval(m->y); }),
         a);
 }
 


### PR DESCRIPTION
Disable example with clang 15 and older due to unsupported parenthesized initialization of aggregates. Also use `unique_ptr` for AST nodes instead of `shared_ptr`.