### PR TITLE
Build code conditionally (default ON)

### DIFF
--- a/01_03_raii_move-semantics/CMakeLists.txt
+++ b/01_03_raii_move-semantics/CMakeLists.txt
@@ -2,6 +2,8 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(01_03_raii_move-semantics raii_move-semantic.md)
 endif()
 
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(01_03_raii_buffer
     code/raii_buffer.cpp
 )
+endif()

--- a/01_04_generic_programming_1_templates/CMakeLists.txt
+++ b/01_04_generic_programming_1_templates/CMakeLists.txt
@@ -3,7 +3,9 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(01_04_templates_part1 templates_part1.md)
 endif()
 
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(01_04_fold_print code/fold_print.cpp)
 
 add_executable(01_04_debug_print_specializations code/debug_print_specializations.cpp)
 target_include_directories(01_04_debug_print_specializations PUBLIC code)
+endif()

--- a/02_01_functional_generic_utilities/CMakeLists.txt
+++ b/02_01_functional_generic_utilities/CMakeLists.txt
@@ -2,6 +2,7 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(02_01_functional_generic_utilities functional_generic_utilities.md)
 endif()
 
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(02_01_apply
     code/apply.cpp
 )
@@ -34,3 +35,4 @@ add_executable(02_00_tuple_storage
 add_executable(02_01_tuple_storage_apply
     code/tuple_storage_apply.cpp
 )
+endif()

--- a/02_03_generic_programming_part2/CMakeLists.txt
+++ b/02_03_generic_programming_part2/CMakeLists.txt
@@ -2,6 +2,7 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(02_03_generic_programming_part2_cpos generic_programming_part2_cpos.md)
 endif()
 
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(02_03_swap
     code/swap.cpp
 )
@@ -13,3 +14,4 @@ add_executable(02_03_swap_cpo
 add_executable(02_03_swap_tag_invoke
     code/swap_tag_invoke.cpp
 )
+endif()

--- a/02_05_example_concept_based_design/CMakeLists.txt
+++ b/02_05_example_concept_based_design/CMakeLists.txt
@@ -2,6 +2,7 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(02_05_example_concept_based_design example_concept_based_design.md)
 endif()
 
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(02_05_test_cursor code/test_cursor.cpp)
 add_test(NAME 02_05_test_cursor COMMAND 02_05_test_cursor)
 
@@ -10,3 +11,4 @@ add_test(NAME 02_05_sol1_filter COMMAND 02_05_sol1_filter)
 
 add_executable(02_05_sol2_to_vector code/sol2_to_vector.cpp)
 add_test(NAME 02_05_sol2_to_vector COMMAND 02_05_sol2_to_vector)
+endif()

--- a/03_01_data_oriented_design/CMakeLists.txt
+++ b/03_01_data_oriented_design/CMakeLists.txt
@@ -2,7 +2,7 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(03_01_data_oriented_design data_oriented_design.md)
 endif()
 
-
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(03_01_dram_burst_mode
     code/dram_burst_mode.cpp
 )
@@ -19,5 +19,6 @@ target_compile_options(03_01_cache_block_size PRIVATE ${CPP_COURSE_AVX_OPTION})
 add_executable(03_01_cache_false_sharing 
     code/cache_false_sharing.cpp
 )
+endif()
 
 add_subdirectory(code/nbody)

--- a/03_01_data_oriented_design/code/nbody/CMakeLists.txt
+++ b/03_01_data_oriented_design/code/nbody/CMakeLists.txt
@@ -1,3 +1,4 @@
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(03_01_nbody)
 target_sources(03_01_nbody
     PRIVATE
@@ -11,3 +12,4 @@ target_sources(03_01_nbody
 
 target_compile_options(03_01_nbody PRIVATE ${CPP_COURSE_MATH_NO_ERRNO_OPTION})
 target_compile_options(03_01_nbody PRIVATE ${CPP_COURSE_AVX_OPTION})
+endif()

--- a/03_02_data_access_algorithms_ranges/CMakeLists.txt
+++ b/03_02_data_access_algorithms_ranges/CMakeLists.txt
@@ -3,5 +3,6 @@ if (${CPP_COURSE_BUILD_SLIDES})
     add_marp_slides(03_02_p2_mdspan p2_mdspan.md)
 endif()
 
-
+if (${CPP_COURSE_BUILD_CODE})
 add_executable(03_02_ranges_snippets code/ranges_snippets.cpp)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
     ${PROJECT_BINARY_DIR}/lib CACHE PATH "Single Directory for all static libraries."
 )
 
+option(CPP_COURSE_BUILD_CODE "Weather to build code." ON)
 option(CPP_COURSE_BUILD_SLIDES "Weather to build slides." ON)
 option(CPP_COURSE_BUILD_SLIDES_PDF "Weather to build slides." ON)
 


### PR DESCRIPTION
- Enable building executables conditionally with `CMake` option `CPP_COURSE_BUILD_CODE` (default `ON`)
- Used for going around compilation issues in local machines (i.e. Apple Silicon Macbooks) if users want to just build the slides